### PR TITLE
자료실 페이지 구현

### DIFF
--- a/front/src/common/menu-items.js
+++ b/front/src/common/menu-items.js
@@ -9,6 +9,7 @@ const MENU_ITEMS = [
 		label: 'Subject',
 		isTitle: false,
 		icon: 'uil-home-alt',
+		url: '/apps/subjects/list'
 		// badge: { variant: 'success', text: '5' },
 		// children: [
 		// 	{
@@ -67,14 +68,14 @@ const MENU_ITEMS = [
 		label: 'QuestionPost',
 		isTitle: false,
 		icon: 'ri-question-line',
-		url: '/apps/questionPost',
+		url: '/apps/questionPost/list',
 	},
 	{
 		key: 'apps-referenceRoom',
 		label: 'ReferenceRoom',
 		isTitle: false,
 		icon: 'ri-folders-line',
-		url: '/apps/referenceRoom',
+		url: '/apps/referenceRoom/list',
 	},
 	{
 		key: 'apps-task',

--- a/front/src/pages/apps/ReferenceRoom/Create/CreateReferenceRoom.jsx
+++ b/front/src/pages/apps/ReferenceRoom/Create/CreateReferenceRoom.jsx
@@ -1,0 +1,91 @@
+import { Row, Col, Card, Form, Button } from 'react-bootstrap';
+import { Form as RHForm } from '@/components';
+import {
+	PageBreadcrumb,
+	FileUploader,
+	TextInput,
+	TextAreaInput,
+} from '@/components';
+import { useReferenceRoomForm } from '../hooks';
+import { useNavigate } from 'react-router-dom';
+
+const CreateReferenceRoom = () => {
+
+	const { schema, handleValidSubmit } = useReferenceRoomForm();
+
+    const navigate = useNavigate();
+
+    const create = () => {
+
+    }
+
+    const cancel = () => {
+        if(confirm("작성중인 내용은 저장되지 않습니다. 정말 취소하시겠습니까?")) {
+            navigate('/apps/referenceRoom/list');
+        }
+    }
+        
+	return (
+		<>
+			<PageBreadcrumb title="Create ReferenceRoom" subName="ReferenceRoom" />
+
+			<Row>
+				<Col>
+					<Card>
+						<Card.Body>
+							<Row>
+								<Col>
+									<RHForm onSubmit={handleValidSubmit} schema={schema}>
+										<Row>
+											<Col xl={12}>
+												<TextInput
+													type="text"
+													name="title"
+													label="Title"
+													placeholder="Enter reference title"
+													containerClass={'mb-3'}
+													key="title"
+												/>
+
+												<TextAreaInput
+													name="content"
+													label="Content"
+													placeholder="Enter some brief about reference.."
+													rows={5}
+													containerClass={'mb-3'}
+													key="content"
+												/>
+                                                <Form.Group className="mb-3 mt-3 mt-xl-0">
+													<Form.Label>Files</Form.Label>
+													<p className="text-muted font-14">
+														Recommended thumbnail size 800x400 (px).
+													</p>
+													<FileUploader />
+												</Form.Group>
+											</Col>
+										</Row>
+
+										<Row className="mt-2">
+											<Col>
+                                                <div className="button-list d-flex flex-wrap gap-2">
+												    <Button variant="primary" onClick={create}>
+													    Create
+												    </Button>
+                                                    <Button variant="danger" onClick={cancel}>
+													    Cancel
+												    </Button>
+                                                </div>
+											</Col>
+										</Row>
+									</RHForm>
+								</Col>
+							</Row>
+						</Card.Body>
+					</Card>
+				</Col>
+			</Row>
+		</>
+	);
+};
+
+export { CreateReferenceRoom };

--- a/front/src/pages/apps/ReferenceRoom/Create/index.jsx
+++ b/front/src/pages/apps/ReferenceRoom/Create/index.jsx
@@ -1,0 +1,1 @@
+export { CreateReferenceRoom as default } from './CreateReferenceRoom';

--- a/front/src/pages/apps/ReferenceRoom/Detail/DetailReferenceRoom.jsx
+++ b/front/src/pages/apps/ReferenceRoom/Detail/DetailReferenceRoom.jsx
@@ -1,0 +1,55 @@
+import axios from 'axios';
+import { Row, Col, Card } from 'react-bootstrap';
+import Files from './Files';
+import { CardTitle, PageBreadcrumb } from '@/components';
+import { useParams } from 'react-router-dom';
+import { useState, useEffect } from 'react';
+
+const DetailReferenceRoom = () => {
+  
+  const {referenceRoomId} = useParams();
+  const [data, setData] = useState(null);
+  const token = localStorage.getItem("_NOTEU_AUTH");
+
+  useEffect(() => {
+    axios.get("http://localhost:8081/subjects/1/references/" + referenceRoomId, {headers:{Authorization:token}})
+    .then(res => {
+      if(res.status === 200) {
+        setData(res.data);
+      } else {
+        console.log("error : " + res.status);
+      }
+    })
+  },[])
+
+  return (
+    <>
+      <PageBreadcrumb title="ReferenceRoom Detail" subName="ReferenceRoom" />
+
+      <Row>
+        <Col>
+          <Card className="d-block">
+            <Card.Body>
+              <CardTitle
+                containerClass="d-flex justify-content-between align-items-center mb-2"
+                icon="ri-more-fill"
+                title={<h3>{data ? data.referenceRoomTitle : 'Loding...'}</h3>}
+                menuItems={[
+                  { label: 'Edit', icon: 'mdi mdi-pencil' },
+                  { label: 'Delete', icon: 'mdi mdi-delete' },
+                ]}
+              />
+
+              <p className="text-muted mb-2">
+                {data ? data.referenceRoomContent : 'Loding...'}
+              </p>
+              <Files reference={data ? data.reference : []} />
+            </Card.Body>
+          </Card>
+        </Col>
+      </Row>
+    </>
+  );
+};
+
+export { DetailReferenceRoom };

--- a/front/src/pages/apps/ReferenceRoom/Detail/Files.jsx
+++ b/front/src/pages/apps/ReferenceRoom/Detail/Files.jsx
@@ -1,0 +1,42 @@
+import { Card, Row } from 'react-bootstrap';
+import { Link } from 'react-router-dom';
+
+const Files = (props) => {
+
+	const { reference } = props;
+
+	return (
+		<Card>
+			<Card.Body>
+				<h5 className="card-title mb-3">DownLoad Files</h5>
+
+				{reference?.map((file) => (
+					<Card className="mb-1 shadow-none border">
+						<div className="p-2">
+							<Row className="align-items-center">
+								<div className="col-auto">
+									<div className="avatar-sm">
+										<span className="avatar-title rounded">{file.referenceType}</span>
+									</div>
+								</div>
+								<div className="col ps-0">
+									<Link to="" className="text-muted fw-bold">
+										{file.referenceName}
+									</Link>
+									<p className="mb-0">{file.referenceSize} MB</p>
+								</div>
+								<div className="col-auto">
+									<Link to="" className="btn btn-link btn-lg text-muted">
+										<i className="ri-download-2-line"></i>
+									</Link>
+								</div>
+							</Row>
+						</div>
+					</Card>
+				 ))}
+			</Card.Body>
+		</Card>
+	);
+};
+
+export default Files;

--- a/front/src/pages/apps/ReferenceRoom/Detail/index.jsx
+++ b/front/src/pages/apps/ReferenceRoom/Detail/index.jsx
@@ -1,0 +1,1 @@
+export { DetailReferenceRoom as default } from './DetailReferenceRoom';

--- a/front/src/pages/apps/ReferenceRoom/List/ListReferenceRoom.jsx
+++ b/front/src/pages/apps/ReferenceRoom/List/ListReferenceRoom.jsx
@@ -1,0 +1,49 @@
+import axios from 'axios';
+import { Link } from 'react-router-dom';
+import { Row, Col, Card } from 'react-bootstrap';
+import { PageBreadcrumb } from '@/components';
+import { ReferenceRoomTable } from './Table';
+import { useState, useEffect } from 'react';
+
+const ListReferenceRoom = () => {
+
+    const [list, setList] = useState([]);
+    const token = localStorage.getItem("_NOTEU_AUTH");
+    console.log(token);
+
+    useEffect(() => {
+        axios.get('http://localhost:8081/subjects/1/references', {headers:{Authorization:token}})
+        .then(res => {
+            if(res.status === 200) {
+                setList(res.data.content);
+            } else {
+                console.log("error : " + res.status);
+            }
+        })
+    },[])
+	return (
+		<>
+			<PageBreadcrumb title="ReferenceRoom List" subName="ReferenceRoom" />
+
+			<Row>
+				<Col xs={12}>
+					<Card>
+						<Card.Body>
+							<Row className="mb-2">
+								<Col sm={5}>
+									<Link to="/apps/referenceRoom/create" className="btn btn-danger btn-rounded mb-2">
+										<i className="mdi mdi-plus-circle me-2"></i> Create
+									</Link>
+								</Col>
+							</Row>
+                            <ReferenceRoomTable list={list}/>
+							
+						</Card.Body>
+					</Card>
+				</Col>
+			</Row>
+		</>
+	);
+};
+
+export { ListReferenceRoom };

--- a/front/src/pages/apps/ReferenceRoom/List/Table.jsx
+++ b/front/src/pages/apps/ReferenceRoom/List/Table.jsx
@@ -1,0 +1,55 @@
+import { Card, Table } from 'react-bootstrap';
+import { Link } from 'react-router-dom';
+
+const ReferenceRoomTable = (props) => {
+
+    const { list } = props;
+
+	return (
+		<Card>
+			<Card.Body>
+				<h4 className="header-title">자료실</h4>
+				<p className="text-muted font-14">
+                    수업에 필요한 자료 파일들을 다운로드 받을 수 있는 공간입니다.
+				</p>
+
+				<Table className="mb-0" hover>
+					<thead>
+						<tr>
+							<th>#</th>
+							<th>Title</th>
+							<th>Date</th>
+							<th>Views</th>
+						</tr>
+					</thead>
+					<tbody>
+						{list.map((item) => {
+                            const createdAt = new Date(item.createdAt);
+                            const year = createdAt.getFullYear();
+                            const month = createdAt.getMonth() + 1;  // getMonth()는 0부터 시작하므로 1을 더해줍니다.
+                            const day = createdAt.getDate();
+                            const hours = createdAt.getHours();
+                            const minutes = createdAt.getMinutes();
+							return (
+								<tr key={item.referenceRoomId}>
+									<th scope="row">{item.referenceRoomId}</th>
+									<td>
+                                        <Link to={`/apps/referenceRoom/detail/${item.referenceRoomId}`}>
+                                            <div>
+                                                {item.referenceRoomTitle}
+                                            </div>
+                                        </Link>
+                                    </td>
+									<td>{`${year}-${month}-${day} ${hours}시 ${minutes}분`}</td>
+									<td>{item.views}</td>
+								</tr>
+							);
+						})}
+					</tbody>
+				</Table>
+			</Card.Body>
+		</Card>
+	);
+};
+
+export { ReferenceRoomTable };

--- a/front/src/pages/apps/ReferenceRoom/List/index.jsx
+++ b/front/src/pages/apps/ReferenceRoom/List/index.jsx
@@ -1,0 +1,1 @@
+export { ListReferenceRoom as default } from './ListReferenceRoom';

--- a/front/src/pages/apps/ReferenceRoom/hooks/index.js
+++ b/front/src/pages/apps/ReferenceRoom/hooks/index.js
@@ -1,0 +1,1 @@
+export { default as useReferenceRoomForm } from './useReferenceRoomForm';

--- a/front/src/pages/apps/ReferenceRoom/hooks/useReferenceRoomForm.js
+++ b/front/src/pages/apps/ReferenceRoom/hooks/useReferenceRoomForm.js
@@ -1,0 +1,23 @@
+import * as yup from 'yup';
+
+export default function useProjectForm() {
+
+	/*
+	 * form validation schema
+	 */
+	const schema = yup.object().shape({
+		name: yup.string().required('Please enter Project Name'),
+	});
+
+	/**
+	 * Handle the form submission
+	 */
+	const handleValidSubmit = (value) => {
+		console.log({ ...value });
+	};
+
+	return {
+		schema,
+		handleValidSubmit,
+	};
+}

--- a/front/src/pages/apps/ReferenceRoom/index.jsx
+++ b/front/src/pages/apps/ReferenceRoom/index.jsx
@@ -1,0 +1,18 @@
+import { lazy } from 'react';
+import { Outlet, Route, Routes } from 'react-router-dom';
+
+const List = lazy(() => import('./List'));
+const Detail = lazy(() => import('./Detail'));
+const Create = lazy(() => import('./Create'));
+
+export default function Apps() {
+	return (
+		<Routes>
+			<Route path="/" element={<Outlet />}>
+				<Route path="list" element={<List />} />
+				<Route path="detail/:referenceRoomId" element={<Detail />} />
+				<Route path="create" element={<Create />} />
+			</Route>
+		</Routes>
+	);
+}

--- a/front/src/pages/apps/index.jsx
+++ b/front/src/pages/apps/index.jsx
@@ -7,6 +7,7 @@ const CRM = lazy(() => import('./crm'));
 const Ecommerce = lazy(() => import('./ecommerce'));
 const Email = lazy(() => import('./email'));
 const Projects = lazy(() => import('./projects'));
+const ReferenceRoom = lazy(() => import('./referenceRoom'));
 const SocialFeed = lazy(() => import('./SocialFeed'));
 const Tasks = lazy(() => import('./tasks'));
 const FileManager = lazy(() => import('./FileManager'));
@@ -21,6 +22,7 @@ export default function Apps() {
 				<Route path="ecommerce/*" element={<Ecommerce />} />
 				<Route path="email/*" element={<Email />} />
 				<Route path="projects/*" element={<Projects />} />
+				<Route path="referenceRoom/*" element={<ReferenceRoom />} />
 				<Route path="social" element={<SocialFeed />} />
 				<Route path="tasks/*" element={<Tasks />} />
 				<Route path="file" element={<FileManager />} />


### PR DESCRIPTION
## 작업 내용
- 자료실 목록 페이지 구현
>  테이블 형태로 자료실 목록 구현
> axios 요청을 통해 DB에 저장된 자료실 게시글 목록 불러오기 성공(token은 header에 하드코딩으로 작성)
> Title 클릭 시 해당 게시글 상세 페이지로 이동
- 추가 해야 할 목록
> 검색창 추가
> 페이지네이션
> Create 버튼 ROLE_TEACHER에게만 보이게 설정

- 자료실 상세 페이지 구현
>axios 요청을 통해 DB에 저장된 자료실 게시글 상세 페이지 구현
- 추가 해야 할 목록
> 업로드 된 파일 다운로드 기능
> 드롭다운 버튼은 ROLE_TEACHER에게만 보이도록 설정

- 자료실 게시글 작성 페이지 구현
> 제목, 내용, 파일 업로드 폼 구현
> Cancel 버튼 클릭 시 자료실 목록으로 이동하도록 구현
- 추가 해야 할 목록
> Create 버튼 클릭 시 axios 요청을 통해 제목, 내용, 파일 목록을 서버로 전송


## 작업 이슈
- #12 

