### PR TITLE
자료실 게시글 삭제 시 이동 경로 수정

### DIFF
--- a/front/src/pages/apps/ReferenceRoom/Detail/DetailReferenceRoom.jsx
+++ b/front/src/pages/apps/ReferenceRoom/Detail/DetailReferenceRoom.jsx
@@ -31,7 +31,7 @@ const DetailReferenceRoom = () => {
     try{
       const response = await axios.delete(`http://localhost:8081/subjects/1/references/${referenceRoomId}`, {headers:{Authorization:token}});
       console.log(response.status);
-      navigate(`/apps/referenceRoom/list/${referenceRoomId}`);
+      navigate(`/apps/referenceRoom/list`);
     } catch(error) {
       console.log("error : " + error);
     }


### PR DESCRIPTION
## 버그 내용
- 자료실 게시글 삭제 시 이동 경로인 list 뒤에 referenceRoomId가 붙어 있었음

## 버그 해결
- 자료실 게시글 삭제 시 이동 경로(list) 뒤에 referenceRoomId 삭제

## 작업 이슈
- #25 

this closes #25 
